### PR TITLE
github-workflows-kt: use another endpoint for healthcheck

### DIFF
--- a/github-workflows-kt/docker-compose.yml
+++ b/github-workflows-kt/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         delay: 10s
         order: start-first
     healthcheck:
-      test: [ "CMD-SHELL", "curl -s -o /dev/null -w '%{http_code}' -L http://localhost:8080 | grep -q 404" ]
+      test: [ "CMD-SHELL", "curl -s -o /dev/null -w '%{http_code}' -L http://localhost:8080/status | grep -q 200" ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
By querying the root path, we can figure out of the service is up, but it generates 404 responses that are then visible in service's monitoring. There's a dedicated endpoint to check if the service is up, and it returns code 200 and `OK` response body.