### PR TITLE
[github-workflows-kt] Add alias for host name for Jaeger

### DIFF
--- a/github-workflows-kt/docker-compose.yml
+++ b/github-workflows-kt/docker-compose.yml
@@ -22,7 +22,10 @@ services:
   jaeger:
     image: jaegertracing/all-in-one:latest
     networks:
-      - reverse_proxy
+      reverse_proxy:
+        # An abstract host name, used by the application. Allows abstracting
+        # out what component is the receiver of traces.
+        aliases: [traces_collector]
     healthcheck:
       test: [ "CMD-SHELL", "wget --spider -q http://localhost:16686 || exit 1" ]
       interval: 30s


### PR DESCRIPTION
This is the first step to be able to add support for viewing aggregated metrics in Jaeger. Following the guide here: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor, we need to switch the traces collector, from Jaeger to OTel Collector. To be able to do it without downtime, we need to do it in three steps:

1. (this PR) Add an alternative host name for the current traces receiver (Jaeger).
2. Switch the app to use the new, abstract host name.
3. Adjust the Docker Compose config to include OTel Collector, available under the new abstract host name.

This change is inspired by https://github.com/jaegertracing/jaeger/blob/4d1c7d8ddc23e5492772b3f985205dd423fbd363/docker-compose/monitor/docker-compose.yml#L23