### PR TITLE
Add Prometheus metrics and allow browsing via Jaeger

### DIFF
--- a/github-workflows-kt/docker-compose.yml
+++ b/github-workflows-kt/docker-compose.yml
@@ -22,7 +22,10 @@ services:
   jaeger:
     image: jaegertracing/all-in-one:latest
     networks:
-      - reverse_proxy
+      reverse_proxy:
+        # An abstract host name, used by the application. Allows abstracting
+        # out what component is the receiver of traces.
+        aliases: [traces_collector]
     healthcheck:
       test: [ "CMD-SHELL", "wget --spider -q http://localhost:16686 || exit 1" ]
       interval: 30s

--- a/github-workflows-kt/docker-compose.yml
+++ b/github-workflows-kt/docker-compose.yml
@@ -8,7 +8,8 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-
+    depends_on:
+      - otel_collector
     networks:
       - reverse_proxy
     labels:
@@ -21,22 +22,48 @@ services:
 
   jaeger:
     image: jaegertracing/all-in-one:latest
-    networks:
-      reverse_proxy:
-        # An abstract host name, used by the application. Allows abstracting
-        # out what component is the receiver of traces.
-        aliases: [traces_collector]
     healthcheck:
       test: [ "CMD-SHELL", "wget --spider -q http://localhost:16686 || exit 1" ]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
+    environment:
+      - METRICS_STORAGE_TYPE=prometheus
+      - PROMETHEUS_SERVER_URL=http://prometheus:9090
+      - PROMETHEUS_QUERY_NAMESPACE=${PROMETHEUS_QUERY_NAMESPACE:-}
+      - PROMETHEUS_QUERY_DURATION_UNIT=${PROMETHEUS_QUERY_DURATION_UNIT:-}
+      - PROMETHEUS_QUERY_NORMALIZE_CALLS=true
+      - PROMETHEUS_QUERY_NORMALIZE_DURATION=true
     labels:
       caddy: jaeger.github-workflows-kt-bindings.colman.com.br
       caddy.reverse_proxy: "{{upstreams 16686}}"
       caddy.basic_auth: "* bcrypt"
       caddy.basic_auth.admin: "JDJhJDEyJHdIU0tJTG45clVDcHQuUmdIN3dvd09ub2VqSDdhakkyL0ZkNnI5OS5XQ2NkTzdHSVNkYmpP"
+
+  otel_collector:
+    networks:
+      reverse_proxy:
+        # An abstract host name, used by the application. Allows abstracting
+        # out what component is the receiver of traces.
+        aliases: [traces_collector]
+    image: otel/opentelemetry-collector-contrib:latest
+    volumes:
+      - "./otel-collector-config.yml:/etc/otelcol/otel-collector-config.yml"
+    command: --config /etc/otelcol/otel-collector-config.yml
+    depends_on:
+      - jaeger
+    ports:
+      - "8889:8889"
+
+  prometheus:
+    networks:
+      - reverse_proxy
+    image: prom/prometheus:latest
+    volumes:
+      - "./prometheus.yml:/etc/prometheus/prometheus.yml"
+    ports:
+      - "9090:9090"
 
   dozzle:
     image: amir20/dozzle:latest

--- a/github-workflows-kt/otel-collector-config.yml
+++ b/github-workflows-kt/otel-collector-config.yml
@@ -1,0 +1,38 @@
+# How the traces arrive to the OTel Collector, i.e. where the app
+# should send them to.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"
+
+# Where the processed traces and metrics should be sent to.
+exporters:
+  # For aggregated metrics.
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+
+  # For raw spans.
+  otlp:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+connectors:
+  spanmetrics:
+
+processors:
+  batch:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [spanmetrics, otlp]
+
+    # The metrics pipeline receives generated span metrics from 'spanmetrics' connector
+    # and pushes to Prometheus exporter, which makes them available for scraping on :8889.
+    metrics/spanmetrics:
+      receivers: [spanmetrics]
+      exporters: [prometheus]

--- a/github-workflows-kt/prometheus.yml
+++ b/github-workflows-kt/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+scrape_configs:
+  - job_name: aggregated-trace-metrics
+    static_configs:
+    - targets: ['traces_collector:8889']
+


### PR DESCRIPTION
Tested (not this config literally, but a very similar one):

![image](https://github.com/user-attachments/assets/b794a848-e264-4469-9d6e-565d5a8e9ae5)
